### PR TITLE
Make CI install the package before testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ test_cmd = py.test
 coverage_cmd = coverage combine && coverage report
 lint_cmd = prospector
 
-install:
+make install: install-requirements
+	$(info * Installing Python package...)
+	python3 setup.py install
+
+install-requirements:
 	$(info * Installing Python requirements...)
 	pip3 install -r requirements.txt
 

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ from setuptools import setup, find_packages
 here = path.abspath(path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.md'), encoding='utf-8') as f:
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(


### PR DESCRIPTION
This change makes the CI system run `setup.py` to install the package, before any of the unit tests are run. Therefore the CI system is now also testing the installation.